### PR TITLE
Updated deprecated Imputer to SimpleImputer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Three things to know:
     1. Project website available at: https://eliavw.github.io/mercs-v5/
+    
     2. Documentation available at: https://mercs.readthedocs.io/en/latest/
+    
     3. Source available at: https://github.com/eliavw/mercs-v5
     

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # mercs-v5
 
 Three things to know:
+
     1. Project website available at: https://eliavw.github.io/mercs-v5/
     
     2. Documentation available at: https://mercs.readthedocs.io/en/latest/

--- a/src/mercs/core/MERCS.py
+++ b/src/mercs/core/MERCS.py
@@ -1,6 +1,6 @@
 import json
 
-from sklearn.preprocessing import Imputer
+from sklearn import impute.SimpleImputer
 from timeit import default_timer
 
 from ..algo.induction import base_ind_algo
@@ -365,9 +365,8 @@ class MERCS(object):
 
         This to fill in missing values later on.
         """
-        imputator = Imputer(missing_values='NaN',
-                            strategy='most_frequent',
-                            axis=0)
+        imputator = SimpleImputer(missing_values='NaN',
+                            strategy='most_frequent')
         imputator.fit(X)
 
         self.imputator = imputator

--- a/src/mercs/core/MERCS.py
+++ b/src/mercs/core/MERCS.py
@@ -105,7 +105,7 @@ class MERCS(object):
         debug_print(msg,V=VERBOSITY)
 
         self.update_settings(mode='fit', **kwargs)
-        self.fit_imputator(X)
+        self.fit_imputator(X, self.s['imputation']['strategy'])
 
         # 2. Selection = Prepare Induction
         self.m_codes = self.perform_selection(self.s['metadata'])
@@ -320,6 +320,11 @@ class MERCS(object):
                                                                 prefix='sel',
                                                                 delimiter=delimiter,
                                                                 **kwargs)
+        elif mode in {'imputation', 'imp'}:
+            self.s['imputation'] = filter_kwargs_update_settings(self.s['imputation'],
+                                                                prefix='imp',
+                                                                delimiter=delimiter,
+                                                                **kwargs)
         elif mode in {'prediction','pred'}:
             self.s['prediction'] = filter_kwargs_update_settings(self.s['prediction'],
                                                                  prefix='pred',
@@ -344,6 +349,7 @@ class MERCS(object):
         elif mode in {'fit'}:
             self.update_settings(mode='induction', delimiter=delimiter, **kwargs)
             self.update_settings(mode='selection', delimiter=delimiter, **kwargs)
+            self.update_settings(mode='imputation', delimiter=delimiter, **kwargs)
         elif mode in {'predict','batch_predict'}:
             self.update_settings(mode='prediction', delimiter=delimiter, **kwargs)
             self.update_settings(mode='queries', delimiter=delimiter, **kwargs)
@@ -359,14 +365,16 @@ class MERCS(object):
 
         return
 
-    def fit_imputator(self, X):
+    def fit_imputator(self, X, imputation_strategy):
         """
         Construct and fit an imputator based on input data_csv.
 
         This to fill in missing values later on.
+
+        :param imputation_strategy:     Imputation method to use
         """
         imputator = SimpleImputer(missing_values=np.nan,
-                            strategy='most_frequent')
+                            strategy=imputation_strategy)
         imputator.fit(X)
 
         self.imputator = imputator

--- a/src/mercs/core/MERCS.py
+++ b/src/mercs/core/MERCS.py
@@ -105,7 +105,7 @@ class MERCS(object):
         debug_print(msg,V=VERBOSITY)
 
         self.update_settings(mode='fit', **kwargs)
-        self.fit_imputator(X, self.s['imputation']['strategy'])
+        self.fit_imputator(X)
 
         # 2. Selection = Prepare Induction
         self.m_codes = self.perform_selection(self.s['metadata'])
@@ -320,11 +320,6 @@ class MERCS(object):
                                                                 prefix='sel',
                                                                 delimiter=delimiter,
                                                                 **kwargs)
-        elif mode in {'imputation', 'imp'}:
-            self.s['imputation'] = filter_kwargs_update_settings(self.s['imputation'],
-                                                                prefix='imp',
-                                                                delimiter=delimiter,
-                                                                **kwargs)
         elif mode in {'prediction','pred'}:
             self.s['prediction'] = filter_kwargs_update_settings(self.s['prediction'],
                                                                  prefix='pred',
@@ -349,7 +344,6 @@ class MERCS(object):
         elif mode in {'fit'}:
             self.update_settings(mode='induction', delimiter=delimiter, **kwargs)
             self.update_settings(mode='selection', delimiter=delimiter, **kwargs)
-            self.update_settings(mode='imputation', delimiter=delimiter, **kwargs)
         elif mode in {'predict','batch_predict'}:
             self.update_settings(mode='prediction', delimiter=delimiter, **kwargs)
             self.update_settings(mode='queries', delimiter=delimiter, **kwargs)
@@ -365,16 +359,14 @@ class MERCS(object):
 
         return
 
-    def fit_imputator(self, X, imputation_strategy):
+    def fit_imputator(self, X):
         """
         Construct and fit an imputator based on input data_csv.
 
         This to fill in missing values later on.
-
-        :param imputation_strategy:     Imputation method to use
         """
         imputator = SimpleImputer(missing_values=np.nan,
-                            strategy=imputation_strategy)
+                            strategy='most_frequent')
         imputator.fit(X)
 
         self.imputator = imputator

--- a/src/mercs/core/MERCS.py
+++ b/src/mercs/core/MERCS.py
@@ -1,6 +1,6 @@
 import json
 
-from sklearn import impute.SimpleImputer
+from sklearn.impute import SimpleImputer
 from timeit import default_timer
 
 from ..algo.induction import base_ind_algo
@@ -365,7 +365,7 @@ class MERCS(object):
 
         This to fill in missing values later on.
         """
-        imputator = SimpleImputer(missing_values='NaN',
+        imputator = SimpleImputer(missing_values=np.nan,
                             strategy='most_frequent')
         imputator.fit(X)
 

--- a/src/mercs/settings/settings.py
+++ b/src/mercs/settings/settings.py
@@ -28,6 +28,8 @@ def create_settings():
                              'its':     1,
                              'param':   1}
 
+    settings['imputation'] = {}
+
     settings['prediction'] = {'type':   'MI',
                               'its':    0.1,
                               'param':  0.95}

--- a/src/mercs/settings/settings.py
+++ b/src/mercs/settings/settings.py
@@ -28,8 +28,6 @@ def create_settings():
                              'its':     1,
                              'param':   1}
 
-    settings['imputation'] = {}
-
     settings['prediction'] = {'type':   'MI',
                               'its':    0.1,
                               'param':  0.95}

--- a/src/mercs/utils/metadata.py
+++ b/src/mercs/utils/metadata.py
@@ -90,17 +90,8 @@ def check_nominal_att(attribute_type,
 
     check_uvalues = attribute_unique_values < nominal_attribute_unique_values_threshold
     check_integer_type = pd.api.types.is_integer_dtype(attribute_type)
-    check_float_type = pd.api.types.is_float_dtype(attribute_type)
 
-    check_case_one = check_integer_type and check_uvalues
-    check_case_two = check_float_type and check_nan and check_uvalues
-
-    if check_case_one:
-        return True
-    elif check_case_two:
-        return True
-    else:
-        return False
+    return check_integer_type and check_uvalues
 
 
 def collect_feature_importances(m_list, m_codes):


### PR DESCRIPTION
Sklearn's Imputer (sklearn.preprocessing) is deprecated and will be removed in a future update. It has been replaced by SimpleImputer (sklearn.impute).